### PR TITLE
Filtering project entries that does not have project_name

### DIFF
--- a/common/models/project.js
+++ b/common/models/project.js
@@ -12,6 +12,9 @@
 //
 function mapProject(project) {
   const _source = project._source;
+  if (!_source.project_name) {
+    return null;
+  }
   return {
     organization: _source.organization ? _source.organization.organization : null,
     organizationUrl: _source.organization ? _source.organization.organization_url : null,
@@ -111,7 +114,9 @@ function transform(projects) {
       continue;
 
     let t = mapProject(p);
-    transformedProjects.push(t);
+    if (t) {
+      transformedProjects.push(t);
+    }
   }
   return transformedProjects;
 }


### PR DESCRIPTION
* This case is due to a creation of a Project from the admin-ui.